### PR TITLE
Update dependencies, and fix Gradle compatibillty with newer JDKs

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Retrofit Converter for MessagePack
 
 ```groovy
 dependencies {
-    compile 'org.komamitsu:retrofit-converter-msgpack:1.0.0'
+    implementation 'org.komamitsu:retrofit-converter-msgpack:1.0.0'
 }
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,8 @@ sourceCompatibility = 1.8
 targetCompatibility = 1.8
 
 task wrapper(type: Wrapper) {
-    gradleVersion = '3.4.1'
+    //INFO: Update this value in gradle-wrapper.properties
+    gradleVersion = '4.3.1'
 }
 
 def deployUsername = project.hasProperty('ossrhUsername') ? ossrhUsername : ''
@@ -27,14 +28,14 @@ repositories {
 }
 
 dependencies {
-    testCompile 'junit:junit:4.12'
-    testCompile 'ch.qos.logback:logback-classic:1.1.8'
-    testCompile 'org.hamcrest:hamcrest-all:1.3'
-    testCompile 'com.squareup.retrofit2:retrofit:2.3.0'
-    testCompile 'com.squareup.okhttp3:mockwebserver:3.8.0'
-    compile 'org.slf4j:slf4j-api:1.7.22'
-    compile 'org.msgpack:jackson-dataformat-msgpack:0.8.13'
-    compileOnly 'com.squareup.retrofit2:retrofit:2.3.0'
+    testImplementation 'junit:junit:4.12'
+    testImplementation 'ch.qos.logback:logback-classic:1.1.8'
+    testImplementation 'org.hamcrest:hamcrest-all:1.3'
+    testImplementation 'com.squareup.retrofit2:retrofit:2.4.0'
+    testImplementation 'com.squareup.okhttp3:mockwebserver:3.10.0'
+    implementation 'org.slf4j:slf4j-api:1.7.22'
+    implementation 'org.msgpack:jackson-dataformat-msgpack:0.8.16'
+    compileOnly 'com.squareup.retrofit2:retrofit:2.4.0'
 }
 
 findbugs {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,6 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.4.1-bin.zip
+#Sun May 6 08:15:22 IST 2018
+#INFO: Update gradleVersion in build.gradle
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.3.1-bin.zip


### PR DESCRIPTION
This PR serves three purposes:
1. Update dependencies and test compatibilty with newer releases of MsgPack, OkHTTP3, and Retrofit.
2. Fix project incompatibility with newer JDKs. Tested this with Oracle JDK 9.0.4
3. Replace `compile`, and `testCompile` in README, 'build.gradle' with `implementation`, and `testImplementation`